### PR TITLE
Add 'event.getFrom()' to *some* event. resolves #7

### DIFF
--- a/com/mewin/WGRegionEvents/WGRegionEventsListener.java
+++ b/com/mewin/WGRegionEvents/WGRegionEventsListener.java
@@ -48,12 +48,14 @@ public class WGRegionEventsListener implements Listener {
     public void onPlayerKick(PlayerKickEvent e)
     {
         Set<ProtectedRegion> regions = playerRegions.remove(e.getPlayer());
+        Location from = e.getPlayer().getLocation();
+
         if (regions != null)
         {
             for(ProtectedRegion region : regions)
             {
-                RegionLeaveEvent leaveEvent = new RegionLeaveEvent(region, e.getPlayer(), MovementWay.DISCONNECT);
-                RegionLeftEvent leftEvent = new RegionLeftEvent(region, e.getPlayer(), MovementWay.DISCONNECT);
+                RegionLeaveEvent leaveEvent = new RegionLeaveEvent(region, e.getPlayer(), MovementWay.DISCONNECT, from);
+                RegionLeftEvent leftEvent = new RegionLeftEvent(region, e.getPlayer(), MovementWay.DISCONNECT, from);
 
                 plugin.getServer().getPluginManager().callEvent(leaveEvent);
                 plugin.getServer().getPluginManager().callEvent(leftEvent);
@@ -65,12 +67,14 @@ public class WGRegionEventsListener implements Listener {
     public void onPlayerQuit(PlayerQuitEvent e)
     {
         Set<ProtectedRegion> regions = playerRegions.remove(e.getPlayer());
+        Location from = e.getPlayer().getLocation();
+
         if (regions != null)
         {
             for(ProtectedRegion region : regions)
             {
-                RegionLeaveEvent leaveEvent = new RegionLeaveEvent(region, e.getPlayer(), MovementWay.DISCONNECT);
-                RegionLeftEvent leftEvent = new RegionLeftEvent(region, e.getPlayer(), MovementWay.DISCONNECT);
+                RegionLeaveEvent leaveEvent = new RegionLeaveEvent(region, e.getPlayer(), MovementWay.DISCONNECT, from);
+                RegionLeftEvent leftEvent = new RegionLeftEvent(region, e.getPlayer(), MovementWay.DISCONNECT, from);
 
                 plugin.getServer().getPluginManager().callEvent(leaveEvent);
                 plugin.getServer().getPluginManager().callEvent(leftEvent);
@@ -81,28 +85,28 @@ public class WGRegionEventsListener implements Listener {
     @EventHandler
     public void onPlayerMove(PlayerMoveEvent e)
     {
-        e.setCancelled(updateRegions(e.getPlayer(), MovementWay.MOVE, e.getTo()));
+        e.setCancelled(updateRegions(e.getPlayer(), MovementWay.MOVE, e.getTo(), e.getFrom()));
     }
     
     @EventHandler
     public void onPlayerTeleport(PlayerTeleportEvent e)
     {
-        e.setCancelled(updateRegions(e.getPlayer(), MovementWay.TELEPORT, e.getTo()));
+        e.setCancelled(updateRegions(e.getPlayer(), MovementWay.TELEPORT, e.getTo(), e.getFrom()));
     }
     
     @EventHandler
     public void onPlayerJoin(PlayerJoinEvent e)
     {
-        updateRegions(e.getPlayer(), MovementWay.SPAWN, e.getPlayer().getLocation());
+        updateRegions(e.getPlayer(), MovementWay.SPAWN, e.getPlayer().getLocation(), null);
     }
     
     @EventHandler
     public void onPlayerRespawn(PlayerRespawnEvent e)
     {
-        updateRegions(e.getPlayer(), MovementWay.SPAWN, e.getRespawnLocation());
+        updateRegions(e.getPlayer(), MovementWay.SPAWN, e.getRespawnLocation(), null);
     }
     
-    private synchronized boolean updateRegions(final Player player, final MovementWay movement, Location to)
+    private synchronized boolean updateRegions(final Player player, final MovementWay movement, Location to, final Location from)
     {
         Set<ProtectedRegion> regions;
         Set<ProtectedRegion> oldRegions;
@@ -131,7 +135,7 @@ public class WGRegionEventsListener implements Listener {
         {
             if (!regions.contains(region))
             {
-                RegionEnterEvent e = new RegionEnterEvent(region, player, movement);
+                RegionEnterEvent e = new RegionEnterEvent(region, player, movement, from);
                 
                 plugin.getServer().getPluginManager().callEvent(e);
                 
@@ -155,7 +159,7 @@ public class WGRegionEventsListener implements Listener {
                             }
                             catch(InterruptedException ex)
                             {}
-                            RegionEnteredEvent e = new RegionEnteredEvent(region, player, movement);
+                            RegionEnteredEvent e = new RegionEnteredEvent(region, player, movement, from);
                             
                             plugin.getServer().getPluginManager().callEvent(e);
                         }
@@ -177,7 +181,7 @@ public class WGRegionEventsListener implements Listener {
                     itr.remove();
                     continue;
                 }
-                RegionLeaveEvent e = new RegionLeaveEvent(region, player, movement);
+                RegionLeaveEvent e = new RegionLeaveEvent(region, player, movement, from);
 
                 plugin.getServer().getPluginManager().callEvent(e);
 
@@ -200,7 +204,7 @@ public class WGRegionEventsListener implements Listener {
                             }
                             catch(InterruptedException ex)
                             {}
-                            RegionLeftEvent e = new RegionLeftEvent(region, player, movement);
+                            RegionLeftEvent e = new RegionLeftEvent(region, player, movement, from);
                             
                             plugin.getServer().getPluginManager().callEvent(e);
                         }

--- a/com/mewin/WGRegionEvents/events/RegionEnterEvent.java
+++ b/com/mewin/WGRegionEvents/events/RegionEnterEvent.java
@@ -2,6 +2,7 @@ package com.mewin.WGRegionEvents.events;
 
 import com.mewin.WGRegionEvents.MovementWay;
 import com.sk89q.worldguard.protection.regions.ProtectedRegion;
+import org.bukkit.Location;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
 
@@ -16,10 +17,11 @@ public class RegionEnterEvent extends RegionEvent implements Cancellable {
      * @param region the region the player is entering
      * @param player the player who triggered the event
      * @param movement the type of movement how the player enters the region
+     * @param from Location the player moved from
      */
-    public RegionEnterEvent(ProtectedRegion region, Player player, MovementWay movement)
+    public RegionEnterEvent(ProtectedRegion region, Player player, MovementWay movement, Location from)
     {
-        super(region, player, movement);
+        super(region, player, movement, from);
         cancelled = false;
         cancellable = true;
         

--- a/com/mewin/WGRegionEvents/events/RegionEnteredEvent.java
+++ b/com/mewin/WGRegionEvents/events/RegionEnteredEvent.java
@@ -2,6 +2,7 @@ package com.mewin.WGRegionEvents.events;
 
 import com.mewin.WGRegionEvents.MovementWay;
 import com.sk89q.worldguard.protection.regions.ProtectedRegion;
+import org.bukkit.Location;
 import org.bukkit.entity.Player;
 
 /**
@@ -15,9 +16,10 @@ public class RegionEnteredEvent extends RegionEvent
      * @param region the region the player entered
      * @param player the player who triggered the event
      * @param movement the type of movement how the player entered the region
+     * @param from Location the player moved from
      */
-    public RegionEnteredEvent(ProtectedRegion region, Player player, MovementWay movement)
+    public RegionEnteredEvent(ProtectedRegion region, Player player, MovementWay movement, Location from)
     {
-        super(region, player, movement);
+        super(region, player, movement, from);
     }
 }

--- a/com/mewin/WGRegionEvents/events/RegionEvent.java
+++ b/com/mewin/WGRegionEvents/events/RegionEvent.java
@@ -6,6 +6,7 @@ package com.mewin.WGRegionEvents.events;
 
 import com.mewin.WGRegionEvents.MovementWay;
 import com.sk89q.worldguard.protection.regions.ProtectedRegion;
+import org.bukkit.Location;
 import org.bukkit.entity.Player;
 import org.bukkit.event.HandlerList;
 import org.bukkit.event.player.PlayerEvent;
@@ -20,12 +21,14 @@ public abstract class RegionEvent extends PlayerEvent {
     
     private ProtectedRegion region;
     private MovementWay movement;
+    private Location from;
     
-    public RegionEvent(ProtectedRegion region, Player player, MovementWay movement)
+    public RegionEvent(ProtectedRegion region, Player player, MovementWay movement, Location from)
     {
         super(player);
         this.region = region;
         this.movement = movement;
+        this.from = from;
     }
 
     @Override
@@ -47,4 +50,6 @@ public abstract class RegionEvent extends PlayerEvent {
     {
         return this.movement;
     }
+
+    public Location getFrom() { return this.from; }
 }

--- a/com/mewin/WGRegionEvents/events/RegionLeaveEvent.java
+++ b/com/mewin/WGRegionEvents/events/RegionLeaveEvent.java
@@ -2,6 +2,7 @@ package com.mewin.WGRegionEvents.events;
 
 import com.mewin.WGRegionEvents.MovementWay;
 import com.sk89q.worldguard.protection.regions.ProtectedRegion;
+import org.bukkit.Location;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
 
@@ -16,13 +17,14 @@ public class RegionLeaveEvent extends RegionEvent  implements Cancellable {
      * @param region the region the player is leaving
      * @param player the player who triggered the event
      * @param movement the type of movement how the player leaves the region
+     * @param from Location the player moved from
      */
-    public RegionLeaveEvent(ProtectedRegion region, Player player, MovementWay movement)
+    public RegionLeaveEvent(ProtectedRegion region, Player player, MovementWay movement, Location from)
     {
-        super(region, player, movement);
+        super(region, player, movement, from);
         cancelled = false;
         cancellable = true;
-        
+
         if (movement == MovementWay.SPAWN
             || movement == MovementWay.DISCONNECT)
         {

--- a/com/mewin/WGRegionEvents/events/RegionLeftEvent.java
+++ b/com/mewin/WGRegionEvents/events/RegionLeftEvent.java
@@ -2,6 +2,7 @@ package com.mewin.WGRegionEvents.events;
 
 import com.mewin.WGRegionEvents.MovementWay;
 import com.sk89q.worldguard.protection.regions.ProtectedRegion;
+import org.bukkit.Location;
 import org.bukkit.entity.Player;
 
 /**
@@ -15,9 +16,10 @@ public class RegionLeftEvent extends RegionEvent
      * @param region the region the player has left
      * @param player the player who triggered the event
      * @param movement the type of movement how the player left the region
+     * @param from Location the player moved from
      */
-    public RegionLeftEvent(ProtectedRegion region, Player player, MovementWay movement)
+    public RegionLeftEvent(ProtectedRegion region, Player player, MovementWay movement, Location from)
     {
-        super(region, player, movement);
+        super(region, player, movement, from);
     }
 }


### PR DESCRIPTION
This will allow developers to easily see what Location a player has come from.

As an example use case, I want to get an ApplicableRegionSet at the Location the Player left a region, allowing me to check not only the claim they left, but all others in that location. To do this, I need the Location of the Player when they left the region, which is what this PR is meant to solve.

NOTE: PlayerJoinEvent and PlayerRespawnEvent will pass null as 'from', as there is no simple way to get the players previous location.
