### PR TITLE
Don't use reflection to get applicable regions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>com.sk89q</groupId>
             <artifactId>worldguard</artifactId>
-            <version>5.8-SNAPSHOT</version>
+            <version>6.0.0-SNAPSHOT</version>
             <type>jar</type>
             <scope>compile</scope>
             <exclusions>

--- a/src/main/java/com/mewin/WGRegionEvents/WGRegionEventsListener.java
+++ b/src/main/java/com/mewin/WGRegionEvents/WGRegionEventsListener.java
@@ -15,7 +15,6 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.*;
 
-import java.lang.reflect.Field;
 import java.util.*;
 
 /**
@@ -153,7 +152,7 @@ public class WGRegionEventsListener implements Listener
             }
         }
         
-        Collection<ProtectedRegion> app = (Collection<ProtectedRegion>) getPrivateValue(appRegions, "applicable");
+        Collection<ProtectedRegion> app = appRegions.getRegions();
         Iterator<ProtectedRegion> itr = regions.iterator();
         while(itr.hasNext())
         {
@@ -193,17 +192,5 @@ public class WGRegionEventsListener implements Listener
         }
         playerRegions.put(player, regions);
         return false;
-    }
-    
-    private Object getPrivateValue(Object obj, String name)
-    {
-        try {
-            Field f = obj.getClass().getDeclaredField(name);
-            f.setAccessible(true);
-            return f.get(obj);
-        } catch (Exception ex) {
-            return null;
-        }
-        
     }
 }


### PR DESCRIPTION
WG 6 introduced support for easily getting the regions in ```ApplicableRegionSet```. This removes the reflection code, using that instead.

This should also fix the problems users are having when running this plugin with WG 6, as ```ApplicableRegionSet``` was changed from a concrete class to an interface.

Fixes #11 