### PR TITLE
Ignore cancelled move / teleport events

### DIFF
--- a/src/main/java/com/mewin/WGRegionEvents/WGRegionEventsListener.java
+++ b/src/main/java/com/mewin/WGRegionEvents/WGRegionEventsListener.java
@@ -70,13 +70,13 @@ public class WGRegionEventsListener implements Listener
         }
     }
     
-    @EventHandler
+    @EventHandler(ignoreCancelled = true)
     public void onPlayerMove(PlayerMoveEvent e)
     {
         e.setCancelled(updateRegions(e.getPlayer(), MovementWay.MOVE, e.getTo(), e));
     }
     
-    @EventHandler
+    @EventHandler(ignoreCancelled = true)
     public void onPlayerTeleport(PlayerTeleportEvent e)
     {
         e.setCancelled(updateRegions(e.getPlayer(), MovementWay.TELEPORT, e.getTo(), e));


### PR DESCRIPTION
WGRE ignores whether an event has already been cancelled when setting the event's cancelled states. This means events that should be cancelled by other plugins won't be cancelled correctly in many scenarios.